### PR TITLE
Tab navigation for confirm delete

### DIFF
--- a/src/components/assessment activities/AssessmentActivityList.vue
+++ b/src/components/assessment activities/AssessmentActivityList.vue
@@ -105,7 +105,7 @@
           </template>
 
           <template v-slot:[`item.edit`]="props">
-            <v-btn text icon color="accent" @click="showEditDialog(props.item)">
+            <v-btn text icon color="accent" @click="showEditDialog(props.item)" v-bind:ref="`ref-${props.item.id}`">
               <v-icon>mdi-pencil</v-icon>
             </v-btn>
           </template>
@@ -168,17 +168,18 @@
               class="ml-5 text--primary"
             >
               (ID: {{ element.id }}) - {{ element.name }}
+            <v-card-actions>
+              <v-spacer></v-spacer>
+              <v-btn text color="accent" @click="overlay = false
+                                                 focusOnEdit(element.id)" ref="confirmation_modal">
+                {{ $t("global.cancel") }}
+              </v-btn>
+              <v-btn text color="error" @click="confirmDelete()">
+                {{ $t("global.delete") }}
+              </v-btn>
+            </v-card-actions>
             </div>
           </v-card-text>
-          <v-card-actions>
-            <v-spacer></v-spacer>
-            <v-btn text color="accent" @click="overlay = false">
-              {{ $t("global.cancel") }}
-            </v-btn>
-            <v-btn text color="error" @click="confirmDelete()">
-              {{ $t("global.delete") }}
-            </v-btn>
-          </v-card-actions>
         </v-card>
       </div>
     </v-overlay>
@@ -189,6 +190,12 @@
 import { mapActions, mapGetters } from "vuex";
 import AssessmentActivityForm from "./AssessmentActivityForm.vue";
 export default {
+  updated() {
+    if (this.$refs.confirmation_modal != undefined &&
+        this.$refs.confirmation_modal.length > 0) {
+      this.$refs.confirmation_modal[0].$el.focus()
+    }
+  },
   name: "AssessmentActivityList",
   components: {
     AssessmentActivityForm,
@@ -280,6 +287,9 @@ export default {
         this.overlay = !this.overlay;
         this.fetchAllAssessmentActivities();
       }
+    },
+    focusOnEdit(focus_on) {
+      this.$refs["ref-"+focus_on].$el.focus();
     },
   },
   data: () => ({

--- a/src/components/assets/AssetList.vue
+++ b/src/components/assets/AssetList.vue
@@ -98,7 +98,7 @@
           </template>
 
           <template v-slot:[`item.edit`]="props">
-            <v-btn text icon color="accent" @click="showEditDialog(props.item)">
+            <v-btn text icon color="accent" @click="showEditDialog(props.item)" v-bind:ref="`ref-${props.item.id}`">
               <v-icon>mdi-pencil</v-icon>
             </v-btn>
           </template>
@@ -159,17 +159,18 @@
               class="ml-5 text--primary"
             >
               (ID: {{ element.id }}) - {{ element.name }}
+            <v-card-actions>
+              <v-spacer></v-spacer>
+              <v-btn text color="accent" @click="overlay = false
+                                                 focusOnEdit(element.id)" ref="confirmation_modal">
+                {{ $t("global.cancel") }}
+              </v-btn>
+              <v-btn text color="error" @click="confirmDelete()">
+                {{ $t("global.delete") }}
+              </v-btn>
+            </v-card-actions>
             </div>
           </v-card-text>
-          <v-card-actions>
-            <v-spacer></v-spacer>
-            <v-btn text color="accent" @click="overlay = false">
-              {{ $t("global.cancel") }}
-            </v-btn>
-            <v-btn text color="error" @click="confirmDelete()">
-              {{ $t("global.delete") }}
-            </v-btn>
-          </v-card-actions>
         </v-card>
       </div>
     </v-overlay>
@@ -180,6 +181,12 @@
 import { mapActions } from "vuex";
 import AssetForm from "./AssetForm.vue";
 export default {
+  updated() {
+    if (this.$refs.confirmation_modal != undefined &&
+        this.$refs.confirmation_modal.length > 0) {
+      this.$refs.confirmation_modal[0].$el.focus()
+    }
+  },
   name: "AssetList",
   components: {
     AssetForm,
@@ -259,6 +266,9 @@ export default {
         this.overlay = !this.overlay;
         this.fetchAllAssets();
       }
+    },
+    focusOnEdit(focus_on) {
+      this.$refs["ref-"+focus_on].$el.focus();
     },
   },
   data: () => ({

--- a/src/components/recommendations/RecommendationList.vue
+++ b/src/components/recommendations/RecommendationList.vue
@@ -124,7 +124,7 @@
           </template>
 
           <template v-slot:[`item.edit`]="props">
-            <v-btn text icon color="accent" @click="showEditDialog(props.item)">
+            <v-btn text icon color="accent" @click="showEditDialog(props.item)" v-bind:ref="`ref-${props.item.id}`">
               <v-icon>mdi-pencil</v-icon>
             </v-btn>
           </template>
@@ -187,17 +187,18 @@
               class="ml-5 text--primary"
             >
               (ID: {{ element.id }}) - {{ element.name }}
+            <v-card-actions>
+              <v-spacer></v-spacer>
+              <v-btn text color="accent" @click="overlay = false
+                                                 focusOnEdit(element.id)" ref="confirmation_modal">
+                {{ $t("global.cancel") }}
+              </v-btn>
+              <v-btn text color="error" @click="confirmDelete()">
+                {{ $t("global.delete") }}
+              </v-btn>
+            </v-card-actions>
             </div>
           </v-card-text>
-          <v-card-actions>
-            <v-spacer></v-spacer>
-            <v-btn text color="accent" @click="overlay = false">
-              {{ $t("global.cancel") }}
-            </v-btn>
-            <v-btn text color="error" @click="confirmDelete()">
-              {{ $t("global.delete") }}
-            </v-btn>
-          </v-card-actions>
         </v-card>
       </div>
     </v-overlay>
@@ -208,6 +209,12 @@
 import { mapActions, mapGetters } from "vuex";
 import RecommendationForm from "./RecommendationForm.vue";
 export default {
+  updated() {
+    if (this.$refs.confirmation_modal != undefined &&
+        this.$refs.confirmation_modal.length > 0) {
+      this.$refs.confirmation_modal[0].$el.focus()
+    }
+  },
   name: "RecommendationList",
   components: {
     RecommendationForm,
@@ -311,6 +318,9 @@ export default {
         this.overlay = !this.overlay;
         this.fetchAllRecommendations();
       }
+    },
+    focusOnEdit(focus_on) {
+      this.$refs["ref-"+focus_on].$el.focus();
     },
   },
   data: () => ({

--- a/src/components/threats/ThreatList.vue
+++ b/src/components/threats/ThreatList.vue
@@ -136,7 +136,7 @@
           </template>
 
           <template v-slot:[`item.edit`]="props">
-            <v-btn text icon color="accent" @click="showEditDialog(props.item)">
+            <v-btn text icon color="accent" @click="showEditDialog(props.item)" v-bind:ref="`ref-${props.item.id}`">
               <v-icon>mdi-pencil</v-icon>
             </v-btn>
           </template>
@@ -230,17 +230,18 @@
               class="ml-5 text--primary"
             >
               (ID: {{ element.id }}) - {{ element.name }}
+            <v-card-actions>
+              <v-spacer></v-spacer>
+              <v-btn text color="accent" @click="overlay = false
+                                                 focusOnEdit(element.id)" ref="confirmation_modal">
+                {{ $t("global.cancel") }}
+              </v-btn>
+              <v-btn text color="error" @click="confirmDelete()">
+                {{ $t("global.delete") }}
+              </v-btn>
+            </v-card-actions>
             </div>
           </v-card-text>
-          <v-card-actions>
-            <v-spacer></v-spacer>
-            <v-btn text color="accent" @click="overlay = false">
-              {{ $t("global.cancel") }}
-            </v-btn>
-            <v-btn text color="error" @click="confirmDelete()">
-              {{ $t("global.delete") }}
-            </v-btn>
-          </v-card-actions>
         </v-card>
       </div>
     </v-overlay>
@@ -252,6 +253,12 @@ import { mapActions } from "vuex";
 import { GChart } from "vue-google-charts";
 import ThreatForm from "./ThreatForm.vue";
 export default {
+  updated() {
+    if (this.$refs.confirmation_modal != undefined &&
+        this.$refs.confirmation_modal.length > 0) {
+      this.$refs.confirmation_modal[0].$el.focus()
+    }
+  },
   name: "ThreatList",
   components: {
     GChart,
@@ -453,6 +460,9 @@ export default {
           this.$refs.rm.$el.focus();
         }, 0);
       }
+    },
+    focusOnEdit(focus_on) {
+      this.$refs["ref-"+focus_on].$el.focus();
     },
   },
   data: () => ({

--- a/src/components/vulnerabilities/VulnerabilityList.vue
+++ b/src/components/vulnerabilities/VulnerabilityList.vue
@@ -124,7 +124,7 @@
           </template>
 
           <template v-slot:[`item.edit`]="props">
-            <v-btn text icon color="accent" @click="showEditDialog(props.item)">
+            <v-btn text icon color="accent" @click="showEditDialog(props.item)" v-bind:ref="`ref-${props.item.id}`">
               <v-icon>mdi-pencil</v-icon>
             </v-btn>
           </template>
@@ -187,17 +187,18 @@
               class="ml-5 text--primary"
             >
               (ID: {{ element.id }}) - {{ element.name }}
+            <v-card-actions>
+              <v-spacer></v-spacer>
+              <v-btn text color="accent" @click="overlay = false
+                                                 focusOnEdit(element.id)" ref="confirmation_modal">
+                {{ $t("global.cancel") }}
+              </v-btn>
+              <v-btn text color="error" @click="confirmDelete()">
+                {{ $t("global.delete") }}
+              </v-btn>
+            </v-card-actions>
             </div>
           </v-card-text>
-          <v-card-actions>
-            <v-spacer></v-spacer>
-            <v-btn text color="accent" @click="overlay = false">
-              {{ $t("global.cancel") }}
-            </v-btn>
-            <v-btn text color="error" @click="confirmDelete()">
-              {{ $t("global.delete") }}
-            </v-btn>
-          </v-card-actions>
         </v-card>
       </div>
     </v-overlay>
@@ -208,9 +209,11 @@
 import { mapActions, mapGetters } from "vuex";
 import VulnerabilityForm from "./VulnerabilityForm.vue";
 export default {
-  name: "VulnerabilityList",
-  components: {
-    VulnerabilityForm,
+  updated() {
+    if (this.$refs.confirmation_modal != undefined &&
+        this.$refs.confirmation_modal.length > 0) {
+      this.$refs.confirmation_modal[0].$el.focus()
+    }
   },
   computed: {
     headers() {
@@ -311,6 +314,9 @@ export default {
         this.overlay = !this.overlay;
         this.fetchAllVulnerabilities();
       }
+    },
+    focusOnEdit(focus_on) {
+      this.$refs["ref-"+focus_on].$el.focus();
     },
   },
   data: () => ({


### PR DESCRIPTION
# Actions

-[x] Focus on the "cancel" button when opening the confirmation overlay
-[x] When closing the overlay, focus on the edit button of the same selected row 
