### PR TITLE
Description Overlay for Threats history view 

### DIFF
--- a/src/components/threats/ThreatForm.vue
+++ b/src/components/threats/ThreatForm.vue
@@ -78,19 +78,19 @@
                 required
               ></v-text-field>
             </v-col>
-            <v-row
-              no-gutters
-              justify="center"
-              v-if="formDataTemp.type === 'Edit'"
-            >
-              <v-col cols="8">
-                <v-text-field
-                  color="accent"
-                  v-model="formDataTemp.threat.observation"
-                  :label="$t('threats.observation')"
-                ></v-text-field>
-              </v-col>
-            </v-row>
+          </v-row>
+          <v-row
+            no-gutters
+            justify="center"
+            v-if="formDataTemp.type === 'Edit'"
+          >
+            <v-col cols="8">
+              <v-text-field
+                color="accent"
+                v-model="formDataTemp.threat.observation"
+                :label="$t('threats.observation')"
+              ></v-text-field>
+            </v-col>
           </v-row>
 
           <v-row

--- a/src/components/threats/ThreatHistory.vue
+++ b/src/components/threats/ThreatHistory.vue
@@ -28,8 +28,10 @@
                   small
                   color="accent"
                   class="trunc"
-                  @click="overlay_observation = true
-                          fillOverlay($t('global.description'), threat.description)"
+                  @click="
+                    overlay_observation = true;
+                    fillOverlay($t('global.description'), threat.description);
+                  "
                 >
                   mdi-dots-vertical
                 </v-icon>
@@ -94,15 +96,21 @@
                     <b class="d-inline text-truncate trunc"
                       >{{ $t("threats.updated_description") }}:
                     </b>
-                    <span class="d-inline-block text-truncate trunc"
-                      >{{ n.description_new }}</span>
+                    <span class="d-inline-block text-truncate trunc">{{
+                      n.description_new
+                    }}</span>
                     <template>
                       <v-icon
                         small
                         color="accent"
                         class="trunc"
-                        @click="overlay_observation = true
-                                fillOverlay($t('threats.updated_description'), n.description_new)"
+                        @click="
+                          overlay_observation = true;
+                          fillOverlay(
+                            $t('threats.updated_description'),
+                            n.description_new
+                          );
+                        "
                       >
                         mdi-dots-vertical
                       </v-icon>
@@ -121,8 +129,13 @@
                         small
                         color="accent"
                         class="trunc"
-                        @click="overlay_observation = true
-                                fillOverlay($t('threats.previous_description'), n.description_old)"
+                        @click="
+                          overlay_observation = true;
+                          fillOverlay(
+                            $t('threats.previous_description'),
+                            n.description_old
+                          );
+                        "
                       >
                         mdi-dots-vertical
                       </v-icon>
@@ -132,16 +145,21 @@
                     <b class="d-inline text-truncate trunc">
                       {{ $t("threats.added_description") }}:
                     </b>
-                    <span class="d-inline-block text-truncate trunc"
-                      >{{ n.description_new }}</span
-                    >
+                    <span class="d-inline-block text-truncate trunc">{{
+                      n.description_new
+                    }}</span>
                     <template>
                       <v-icon
                         small
                         color="accent"
                         class="trunc"
-                        @click="overlay_observation = true
-                                fillOverlay($t('threats.added_description'), n.description_new)"
+                        @click="
+                          overlay_observation = true;
+                          fillOverlay(
+                            $t('threats.added_description'),
+                            n.description_new
+                          );
+                        "
                       >
                         mdi-dots-vertical
                       </v-icon>
@@ -159,8 +177,13 @@
                         small
                         color="accent"
                         class="trunc"
-                        @click="overlay_observation = true
-                                fillOverlay($t('threats.deleted_description'), n.description_old)"
+                        @click="
+                          overlay_observation = true;
+                          fillOverlay(
+                            $t('threats.deleted_description'),
+                            n.description_old
+                          );
+                        "
                       >
                         mdi-dots-vertical
                       </v-icon>
@@ -251,29 +274,23 @@
         </v-timeline>
       </v-col>
     </v-row>
-    <v-overlay :dark="false" :value="overlay_observation" >
-      <v-card outlined >
+    <v-overlay :dark="false" :value="overlay_observation">
+      <v-card outlined>
         <v-card-text>
           <p class="display-2 text--secondary">
             {{ description_title }}
           </p>
-          <div  class="scrollable_observations">
+          <div class="scrollable_observations">
             {{ description_value }}
-         </div>
+          </div>
         </v-card-text>
         <v-card-actions>
-          <v-btn
-            text
-            plain
-            color="accent"
-            @click="
-              overlay_observation = false;"
-          >
+          <v-btn text plain color="accent" @click="overlay_observation = false">
             {{ $t("global.close_sheet") }}
           </v-btn>
         </v-card-actions>
       </v-card>
-    </v-overlay>    
+    </v-overlay>
   </v-container>
 </template>
 
@@ -300,10 +317,10 @@ export default {
       );
       return tempObj[this.$i18n.locale];
     },
-    fillOverlay(title, description){
+    fillOverlay(title, description) {
       this.description_title = title;
       this.description_value = description;
-    }  
+    },
   },
 };
 </script>
@@ -313,7 +330,7 @@ export default {
   max-width: 360px;
   vertical-align: bottom;
 }
-.scrollable_observations{
+.scrollable_observations {
   max-height: 350px;
   max-width: 800px;
   overflow: auto;

--- a/src/components/threats/ThreatHistory.vue
+++ b/src/components/threats/ThreatHistory.vue
@@ -23,19 +23,17 @@
               <span class="d-inline-block text-truncate trunc">{{
                 threat.description
               }}</span>
-              <v-tooltip bottom color="accent">
-                <template v-slot:activator="{ on }">
-                  <v-icon
-                    small
-                    color="accent"
-                    v-on="on"
-                    class="tooltipIcon trunc"
-                  >
-                    mdi-dots-vertical
-                  </v-icon>
-                </template>
-                <span>{{ threat.description }}</span>
-              </v-tooltip>
+              <template>
+                <v-icon
+                  small
+                  color="accent"
+                  class="trunc"
+                  @click="overlay_export = true
+                          fillOverlay($t('global.description'), threat.description)"
+                >
+                  mdi-dots-vertical
+                </v-icon>
+              </template>
             </div>
             <div v-if="threat.threat_type_name">
               <b>{{ $t("global.threat_type") }}: </b
@@ -96,22 +94,19 @@
                     <b class="d-inline text-truncate trunc"
                       >{{ $t("threats.updated_description") }}:
                     </b>
-                    <span class="d-inline-block text-truncate trunc">{{
-                      n.description_new
-                    }}</span>
-                    <v-tooltip bottom color="accent">
-                      <template v-slot:activator="{ on }">
-                        <v-icon
-                          small
-                          color="accent"
-                          v-on="on"
-                          class="tooltipIcon trunc"
-                        >
-                          mdi-dots-vertical
-                        </v-icon>
-                      </template>
-                      <span>{{ n.description_new }}</span>
-                    </v-tooltip>
+                    <span class="d-inline-block text-truncate trunc"
+                      >{{ n.description_new }}</span>
+                    <template>
+                      <v-icon
+                        small
+                        color="accent"
+                        class="trunc"
+                        @click="overlay_export = true
+                                fillOverlay($t('threats.updated_description'), n.description_new)"
+                      >
+                        mdi-dots-vertical
+                      </v-icon>
+                    </template>
 
                     <br />
 
@@ -121,57 +116,55 @@
                     <span class="d-inline-block text-truncate trunc"
                       ><strike>{{ n.description_old }}</strike></span
                     >
-                    <v-tooltip bottom color="accent">
-                      <template v-slot:activator="{ on }">
-                        <v-icon
-                          small
-                          color="accent"
-                          v-on="on"
-                          class="tooltipIcon trunc"
-                        >
-                          mdi-dots-vertical
-                        </v-icon>
-                      </template>
-                      <span>{{ n.description_old }}</span>
-                    </v-tooltip>
+                    <template>
+                      <v-icon
+                        small
+                        color="accent"
+                        class="trunc"
+                        @click="overlay_export = true
+                                fillOverlay($t('threats.previous_description'), n.description_old)"
+                      >
+                        mdi-dots-vertical
+                      </v-icon>
+                    </template>
                   </div>
                   <div v-if="n.description_new && !n.description_old">
-                    <b>{{ $t("threats.added_description") }}: </b>
-                    <span class="d-inline-block text-truncate trunc">{{
-                      n.description_new
-                    }}</span>
-                    <v-tooltip bottom color="accent">
-                      <template v-slot:activator="{ on }">
-                        <v-icon
-                          small
-                          color="accent"
-                          v-on="on"
-                          class="tooltipIcon trunc"
-                        >
-                          mdi-dots-vertical
-                        </v-icon>
-                      </template>
-                      <span>{{ n.description_new }}</span>
-                    </v-tooltip>
+                    <b class="d-inline text-truncate trunc">
+                      {{ $t("threats.added_description") }}:
+                    </b>
+                    <span class="d-inline-block text-truncate trunc"
+                      >{{ n.description_new }}</span
+                    >
+                    <template>
+                      <v-icon
+                        small
+                        color="accent"
+                        class="trunc"
+                        @click="overlay_export = true
+                                fillOverlay($t('threats.added_description'), n.description_new)"
+                      >
+                        mdi-dots-vertical
+                      </v-icon>
+                    </template>
                   </div>
                   <div v-if="!n.description_new && n.description_old">
-                    <b>{{ $t("threats.deleted_description") }}: </b
-                    ><span class="d-inline-block text-truncate trunc"
+                    <b class="d-inline text-truncate trunc">
+                      {{ $t("threats.deleted_description") }}:
+                    </b>
+                    <span class="d-inline-block text-truncate trunc"
                       ><strike>{{ n.description_old }}</strike></span
                     >
-                    <v-tooltip bottom color="accent">
-                      <template v-slot:activator="{ on }">
-                        <v-icon
-                          small
-                          color="accent"
-                          v-on="on"
-                          class="tooltipIcon trunc"
-                        >
-                          mdi-dots-vertical
-                        </v-icon>
-                      </template>
-                      <span>{{ n.description_old }}</span>
-                    </v-tooltip>
+                    <template>
+                      <v-icon
+                        small
+                        color="accent"
+                        class="trunc"
+                        @click="overlay_export = true
+                                fillOverlay($t('threats.deleted_description'), n.description_old)"
+                      >
+                        mdi-dots-vertical
+                      </v-icon>
+                    </template>
                   </div>
                 </div>
                 <div v-if="n.threat_type_name_new || n.threat_type_name_old">
@@ -258,6 +251,27 @@
         </v-timeline>
       </v-col>
     </v-row>
+    <v-overlay :dark="false" :value="overlay_export">
+      <v-card outlined>
+        <v-card-text>
+          <p class="display-2 text--secondary">
+            {{ description_title }}
+          </p>
+          {{ description_value }}
+        </v-card-text>
+        <v-card-actions>
+          <v-btn
+            text
+            plain
+            color="accent"
+            @click="
+              overlay_export = false;"
+          >
+            {{ $t("global.close_sheet") }}
+          </v-btn>
+        </v-card-actions>
+      </v-card>
+    </v-overlay>    
   </v-container>
 </template>
 
@@ -266,7 +280,11 @@ import { mapGetters } from "vuex";
 //import ThreatList from "../components/threats/ThreatList.vue";
 export default {
   props: ["threat", "audits"],
-  data: () => ({}),
+  data: () => ({
+    overlay_export: false,
+    description_value: "",
+    description_title: ""
+  }),
   components: {
     //ThreatList,
   },
@@ -280,6 +298,10 @@ export default {
       );
       return tempObj[this.$i18n.locale];
     },
+    fillOverlay(title, description){
+      this.description_title = title;
+      this.description_value = description;
+    }  
   },
 };
 </script>
@@ -288,8 +310,5 @@ export default {
 .trunc {
   max-width: 360px;
   vertical-align: bottom;
-}
-.tooltipIcon {
-  float: right;
 }
 </style>

--- a/src/components/threats/ThreatHistory.vue
+++ b/src/components/threats/ThreatHistory.vue
@@ -28,7 +28,7 @@
                   small
                   color="accent"
                   class="trunc"
-                  @click="overlay_export = true
+                  @click="overlay_observation = true
                           fillOverlay($t('global.description'), threat.description)"
                 >
                   mdi-dots-vertical
@@ -101,7 +101,7 @@
                         small
                         color="accent"
                         class="trunc"
-                        @click="overlay_export = true
+                        @click="overlay_observation = true
                                 fillOverlay($t('threats.updated_description'), n.description_new)"
                       >
                         mdi-dots-vertical
@@ -121,7 +121,7 @@
                         small
                         color="accent"
                         class="trunc"
-                        @click="overlay_export = true
+                        @click="overlay_observation = true
                                 fillOverlay($t('threats.previous_description'), n.description_old)"
                       >
                         mdi-dots-vertical
@@ -140,7 +140,7 @@
                         small
                         color="accent"
                         class="trunc"
-                        @click="overlay_export = true
+                        @click="overlay_observation = true
                                 fillOverlay($t('threats.added_description'), n.description_new)"
                       >
                         mdi-dots-vertical
@@ -159,7 +159,7 @@
                         small
                         color="accent"
                         class="trunc"
-                        @click="overlay_export = true
+                        @click="overlay_observation = true
                                 fillOverlay($t('threats.deleted_description'), n.description_old)"
                       >
                         mdi-dots-vertical
@@ -251,13 +251,15 @@
         </v-timeline>
       </v-col>
     </v-row>
-    <v-overlay :dark="false" :value="overlay_export">
-      <v-card outlined>
+    <v-overlay :dark="false" :value="overlay_observation" >
+      <v-card outlined >
         <v-card-text>
           <p class="display-2 text--secondary">
             {{ description_title }}
           </p>
-          {{ description_value }}
+          <div  class="scrollable_observations">
+            {{ description_value }}
+         </div>
         </v-card-text>
         <v-card-actions>
           <v-btn
@@ -265,7 +267,7 @@
             plain
             color="accent"
             @click="
-              overlay_export = false;"
+              overlay_observation = false;"
           >
             {{ $t("global.close_sheet") }}
           </v-btn>
@@ -281,9 +283,9 @@ import { mapGetters } from "vuex";
 export default {
   props: ["threat", "audits"],
   data: () => ({
-    overlay_export: false,
+    overlay_observation: false,
     description_value: "",
-    description_title: ""
+    description_title: "",
   }),
   components: {
     //ThreatList,
@@ -310,5 +312,10 @@ export default {
 .trunc {
   max-width: 360px;
   vertical-align: bottom;
+}
+.scrollable_observations{
+  max-height: 350px;
+  max-width: 800px;
+  overflow: auto;
 }
 </style>

--- a/src/components/threats/ThreatHistory.vue
+++ b/src/components/threats/ThreatHistory.vue
@@ -274,13 +274,19 @@
         </v-timeline>
       </v-col>
     </v-row>
-    <v-overlay :dark="false" :value="overlay_observation">
-      <v-card outlined>
+    <v-overlay :dark="false" :value="overlay_observation" @keydown.esc="toggle">
+      <v-card outlined v-click-outside="toggle">
         <v-card-text>
           <p class="display-2 text--secondary">
             {{ description_title }}
           </p>
-          <div class="scrollable_observations">
+          <div
+            :style="`
+          max-height: ${(windowSize.y * 50) / 100}px;
+          max-width: ${(windowSize.x * 50) / 100}px;
+          overflow-y: auto;`"
+            v-resize="onResize"
+          >
             {{ description_value }}
           </div>
         </v-card-text>
@@ -303,7 +309,22 @@ export default {
     overlay_observation: false,
     description_value: "",
     description_title: "",
+    windowSize: {
+      x: 0,
+      y: 0,
+    },
   }),
+  mounted() {
+    document.addEventListener("keydown", (e) => {
+      // If  ESC key was pressed
+      if (e.keyCode == 27) {
+        this.overlay_observation = false;
+
+        // or if you have created a dialog as a custom component, emit an event
+        // this.$emit('closeDialog')
+      }
+    });
+  },
   components: {
     //ThreatList,
   },
@@ -321,6 +342,12 @@ export default {
       this.description_title = title;
       this.description_value = description;
     },
+    onResize() {
+      this.windowSize = { x: window.innerWidth, y: window.innerHeight };
+    },
+    toggle() {
+      this.overlay_observation = !this.overlay_observation;
+    },
   },
 };
 </script>
@@ -329,10 +356,5 @@ export default {
 .trunc {
   max-width: 360px;
   vertical-align: bottom;
-}
-.scrollable_observations {
-  max-height: 350px;
-  max-width: 800px;
-  overflow: auto;
 }
 </style>


### PR DESCRIPTION
# Actions

- [x] Add overlay to show the descriptions (added, modified, and old) on the threats history view 

# Support files 

![Screenshot 2022-03-29 212222](https://user-images.githubusercontent.com/4895262/160732282-c5cbd4dc-5958-4a57-9cfd-2a81c412c344.png)
