### PR TITLE
Fix js warning when creating a threat 

### DIFF
--- a/src/store/modules/threats.js
+++ b/src/store/modules/threats.js
@@ -154,10 +154,7 @@ const actions = {
   },
   async addThreat({ commit }, threat) {
     const response = await ipcRenderer.sendSync("insert", ["threats", threat]);
-    const asset_response = await ipcRenderer.sendSync("getOne", [
-      "assets",
-      threat,
-    ]);
+    const asset_response = ipcRenderer.sendSync("getOne", ["assets", threat]);
     if (response.length == 0) {
       this.dispatch("setNotification", {
         text: i18n.t("threats.insert_error"),


### PR DESCRIPTION
# Actions

- [x] Remove the await from the getOne call to remove the js warning