### PR TITLE
Readable (screen reader) edit and delete buttons 

### DIFF
--- a/src/components/assessment activities/AssessmentActivityList.vue
+++ b/src/components/assessment activities/AssessmentActivityList.vue
@@ -111,6 +111,7 @@
               icon
               color="accent"
               @click="showEditDialog(props.item)"
+              :aria-placeholder="$t('global.edit') + ': ' + `${props.item.name}`"
               v-bind:ref="`ref-${props.item.id}`"
             >
               <v-icon>mdi-pencil</v-icon>
@@ -120,6 +121,7 @@
               text
               icon
               color="accent"
+              :aria-placeholder="$t('global.delete') + ': ' + `${props.item.name}`"
               @click="showDeleteDialog([props.item])"
             >
               <v-icon>mdi-delete</v-icon>

--- a/src/components/assets/AssetList.vue
+++ b/src/components/assets/AssetList.vue
@@ -103,6 +103,7 @@
               text
               icon
               color="accent"
+              :aria-placeholder="$t('global.edit') + ': ' + `${props.item.name}`"
               @click="showEditDialog(props.item)"
               v-bind:ref="`ref-${props.item.id}`"
             >
@@ -113,6 +114,7 @@
               text
               icon
               color="accent"
+              :aria-placeholder="$t('global.delete') + ': ' + `${props.item.name}`"
               @click="showDeleteDialog([props.item])"
             >
               <v-icon>mdi-delete</v-icon>

--- a/src/components/recommendations/RecommendationList.vue
+++ b/src/components/recommendations/RecommendationList.vue
@@ -130,6 +130,7 @@
               icon
               color="accent"
               @click="showEditDialog(props.item)"
+              :aria-placeholder="$t('global.edit') + ': ' + `${props.item.name}`"
               v-bind:ref="`ref-${props.item.id}`"
             >
               <v-icon>mdi-pencil</v-icon>
@@ -139,6 +140,7 @@
               text
               icon
               color="accent"
+              :aria-placeholder="$t('global.delete') + ': ' + `${props.item.name}`"
               @click="showDeleteDialog([props.item])"
             >
               <v-icon>mdi-delete</v-icon>

--- a/src/components/threats/ThreatList.vue
+++ b/src/components/threats/ThreatList.vue
@@ -142,6 +142,7 @@
               icon
               color="accent"
               @click="showEditDialog(props.item)"
+              :aria-placeholder="$t('global.edit') + ': ' + `${props.item.name}`"
               v-bind:ref="`ref-${props.item.id}`"
             >
               <v-icon>mdi-pencil</v-icon>
@@ -150,6 +151,7 @@
               text
               icon
               color="accent"
+              :aria-placeholder="$t('global.delete') + ': ' + `${props.item.name}`"
               @click="showDeleteDialog([props.item])"
             >
               <v-icon>mdi-delete</v-icon>
@@ -158,6 +160,7 @@
               text
               icon
               color="accent"
+              :aria-placeholder="$t('threats.threat_history.history_changes') + ': ' + `${props.item.name}`"
               @click="selectActiveThreatH(props.item)"
             >
               <v-icon>mdi-history</v-icon>

--- a/src/components/vulnerabilities/VulnerabilityList.vue
+++ b/src/components/vulnerabilities/VulnerabilityList.vue
@@ -130,6 +130,7 @@
               icon
               color="accent"
               @click="showEditDialog(props.item)"
+              :aria-placeholder="$t('global.edit') + ': ' + `${props.item.name}`"
               v-bind:ref="`ref-${props.item.id}`"
             >
               <v-icon>mdi-pencil</v-icon>
@@ -139,6 +140,7 @@
               text
               icon
               color="accent"
+              :aria-placeholder="$t('global.delete') + ': ' + `${props.item.name}`"
               @click="showDeleteDialog([props.item])"
             >
               <v-icon>mdi-delete</v-icon>

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -147,7 +147,8 @@
       "old": "Old:",
       "delete": "Delete threat history",
       "confirm_delete": "This action will delete the selected element from this threat's history",
-      "confirm_delete_all": "This action will wipe this threat's history"
+      "confirm_delete_all": "This action will wipe this threat's history",
+      "history_changes": "List history of changes"
     },
     "risk_matrix": {
       "vcard_name": "Risk matrix",

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -131,7 +131,7 @@
     "insert_error": "La amenaza no pudo ser insertada. Por favor compruebe que el nombre sea único",
     "threat_history": {
       "identifier": "ID",
-      "name": "Histórico de cambios':",
+      "name": "Histórico de cambios:",
       "changes_history_empty": "Ningun cambio encontrado.",
       "change_number": "Cambio ",
       "created": "Creación",
@@ -147,7 +147,8 @@
       "old": "Viejo:",
       "delete": "Eliminar histórico de cambios",
       "confirm_delete": "Esta acción eliminará el elemento seleccionado del histórico de la amenaza",
-      "confirm_delete_all": "Esta acción eliminará todo el histórico de la amenaza"
+      "confirm_delete_all": "Esta acción eliminará todo el histórico de la amenaza",
+      "history_changes": "Listar historico de cambios"
     },
     "risk_matrix": {
       "vcard_name": "Matriz de riesgo",

--- a/src/locales/pt-br.json
+++ b/src/locales/pt-br.json
@@ -147,7 +147,8 @@
       "old": "Velha:",
       "delete": "Excluir histórico de alterações",
       "confirm_delete": "Esta ação removerá o item selecionado do histórico de ameaças",
-      "confirm_delete_all": "Esta ação excluirá todo o histórico da ameaça"
+      "confirm_delete_all": "Esta ação excluirá todo o histórico da ameaça",
+      "history_changes": "Listar histórico de alterações"
     },
     "risk_matrix": {
       "vcard_name": "Matriz de risco",


### PR DESCRIPTION
# Actions

- [x] Add aria-placeholders to the edit and delete buttons, specifying the name of the element to edit/delete
- [x] Add aria-placeholder to the list threat history button specifying the name of the threat to list the changes
- [x] Add translations for the "list history changes" message
- [x] Removed a single quotation from the Spanish name  of the threat_history that wasn't supposed to be there 
